### PR TITLE
search with spotify and add to local db

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -3,7 +3,13 @@ class ArtistsController < ApplicationController
 
   def index
     if params[:query].present?
+      @query = params[:query]
       @artists = Artist.search_by_name(params[:query])
+      spotify_artists = RSpotify::Artist.search(params[:query])
+      @spotify_artists = []
+      spotify_artists.each do |artist|
+        @spotify_artists << Artist.new(name: artist.name, spotify_id: artist.id, image_url: artist.images.first ? artist.images.first["url"] : "https://images.unsplash.com/photo-1614680376593-902f74cf0d41?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1934&q=80")
+      end
     else
       @artists = Artist.all
     end
@@ -19,6 +25,18 @@ class ArtistsController < ApplicationController
   def toggle_follow
     @artist = Artist.find(params[:id])
     current_user.favorited?(@artist) ? current_user.unfavorite(@artist) : current_user.favorite(@artist)
+  end
+
+  def new_follow
+    artist = Artist.new(artist_params)
+    artist.save!
+    current_user.favorite(artist)
+  end
+
+  private
+
+  def artist_params
+    params.require(:artist).permit(:name, :spotify_id, :image_url)
   end
 
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -6,4 +6,9 @@ class Artist < ApplicationRecord
     using: {
       tsearch: { prefix: true } # <-- now `superman batm` will return something!
     }
+    pg_search_scope :search_by_id,
+    against: :spotify_id,
+    using: {
+      tsearch: { prefix: true } # <-- now `superman batm` will return something!
+    }
 end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -6,6 +6,12 @@
   <div class="search mt-3">
     <%= render "components/search" %>
   </div>
+
+  <% if @query %>
+    <h2>Search results for <%= @query %>:</h2>
+    <%= link_to "Back to Browse", artists_path %>
+  <% end %>
+
   <div class="artist-cards row">
     <% @artists.each do |artist| %>
       <div class="col-sm">
@@ -13,4 +19,13 @@
       </div>
     <% end %>
   </div>
+
+  <% if @query %>
+      <% @spotify_artists.each do |artist| %>
+        <% id = artist.spotify_id %>
+        <% unless Artist.search_by_id(id).first %>
+          <%= render "components/spotify_artist_card", artist: artist, user: current_user %>
+        <% end %>
+      <% end %>
+  <% end %>
 </div>

--- a/app/views/components/_spotify_artist_card.html.erb
+++ b/app/views/components/_spotify_artist_card.html.erb
@@ -1,0 +1,9 @@
+<div class="card mb-3 text-white bg-info rounded-lg shadow" data-filter-target="filterable" data-filter-key="<%= artist.name.downcase %>">
+  <%= image_tag artist.image_url, alt: "Artist Image", class: "card-img-top" %>
+  <div class="card-body" data-controller="follow">
+    <h5 class="card-title"><%= artist.name %></h5>
+    <%= link_to new_follow_path( artist: {name: artist.name, spotify_id: artist.spotify_id, image_url: artist.image_url}), remote: true, method: :post, data: { action: "click->follow#toggle"} do %>
+      <%= user.favorited?(artist) ? '<i class="fas fa-heart" data-follow-target="icon"></i>'.html_safe : '<i class="far fa-heart" data-follow-target="icon"></i>'.html_safe %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
+  post 'new_follow', to: 'artists#new_follow'
   resources :artists, only: [ :index, :create ] do
     member do
       post 'toggle_follow', to: 'artists#toggle_follow'


### PR DESCRIPTION
The search function on artists page now works as follows:

1. While searching, js is hiding any cards that don't match your search
2. After submitting the search query:

- pg search is used to display artists that match from local db
- A search request is sent to spotify using rspotify gem and returns an array of artists, which is converted into Artist instances
- Any of these new artists from spotify that are not already in local db are displayed
- The follow button on the spotify artists creates the new instance in the db and then follows