### PR TITLE
config sidekiq-throttled gem; added throttling to get new releases job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'sidekiq'
 gem 'sidekiq-failures', '~> 1.0'
 gem 'rails_admin', '~> 2.0'
 gem 'rollbar'
+gem "sidekiq-throttled"
 
 group :development, :test do  gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.3.1)
+    redis-prescription (1.0.0)
     regexp_parser (2.1.1)
     remotipart (1.4.4)
     responders (3.0.1)
@@ -299,6 +300,10 @@ GEM
       redis (>= 4.2.0)
     sidekiq-failures (1.0.0)
       sidekiq (>= 4.0.0)
+    sidekiq-throttled (0.13.0)
+      concurrent-ruby
+      redis-prescription
+      sidekiq
     simple_calendar (2.4.2)
       rails (>= 3.0)
     simple_form (5.1.0)
@@ -391,6 +396,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-failures (~> 1.0)
+  sidekiq-throttled
   simple_calendar (~> 2.4)
   simple_form
   spring

--- a/app/jobs/get_new_releases_job.rb
+++ b/app/jobs/get_new_releases_job.rb
@@ -1,5 +1,15 @@
 class GetNewReleasesJob < ApplicationJob
+  include Sidekiq::Throttled::Worker
   queue_as :default
+
+  sidekiq_options :queue => :default
+
+  sidekiq_throttle({
+    # Allow maximum 10 concurrent jobs of this class at a time.
+    # :concurrency => { :limit => 10 },
+    # Allow maximum 1 job processed per second.
+    :threshold => { :limit => 1, :period => 1.second }
+  })
 
   def perform(artist)
     puts "Getting new releases for #{artist.name}..."

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,2 @@
+require "sidekiq/throttled"
+Sidekiq::Throttled.setup!


### PR DESCRIPTION
* configured sidekick-throttled gem
* set get_new_releases_job to run one job per second
* seems to be avoiding spotify 429 too many requests error for now