### PR TITLE
manual job throttling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'letter_opener', group: :development
 gem 'postmark-rails'
 gem 'rails_admin', '~> 2.0'
 gem 'rollbar'
-gem "sidekiq-throttled"
 
 group :development, :test do  gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,18 +129,13 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
-    json (2.5.1)
-    jwt (2.2.3)
-    launchy (2.4.3)
-      addressable (~> 2.3)
-    letter_opener (1.7.0)
-      launchy (~> 2.2)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
+    json (2.5.1)
     jwt (2.2.3)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -154,6 +149,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -409,7 +408,6 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-failures (~> 1.0)
-  sidekiq-throttled
   simple_calendar (~> 2.4)
   simple_form
   spring

--- a/app/jobs/get_new_releases_job.rb
+++ b/app/jobs/get_new_releases_job.rb
@@ -1,15 +1,5 @@
 class GetNewReleasesJob < ApplicationJob
-  include Sidekiq::Throttled::Worker
   queue_as :default
-
-  sidekiq_options :queue => :default
-
-  sidekiq_throttle({
-    # Allow maximum 10 concurrent jobs of this class at a time.
-    # :concurrency => { :limit => 10 },
-    # Allow maximum 1 job processed per second.
-    :threshold => { :limit => 1, :period => 1.second }
-  })
 
   def perform(artist)
     puts "Getting new releases for #{artist.name}..."

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,2 +1,0 @@
-require "sidekiq/throttled"
-Sidekiq::Throttled.setup!

--- a/lib/tasks/artist.rake
+++ b/lib/tasks/artist.rake
@@ -5,6 +5,7 @@ namespace :artist do
     puts "Checking new releases for #{artists.size} artists..."
     artists.each do |artist|
       GetNewReleasesJob.perform_later(artist)
+      sleep 1.second
     end
   end
 


### PR DESCRIPTION
* removed Sidekiq-throttled after reading [this answer](https://stackoverflow.com/questions/33698433/configure-sidekiq-to-work-only-two-requests-per-second) which makes it seem like no matter how slowly you schedule Sidekiq jobs, Sidekiq will process them immediately by default
* updated rake task to schedule each job and then sleep for 1 second before moving on to the next one

fixes #60 